### PR TITLE
Support for headless

### DIFF
--- a/src/main/java/com/abmash/core/browser/BrowserConfig.java
+++ b/src/main/java/com/abmash/core/browser/BrowserConfig.java
@@ -49,6 +49,11 @@ public class BrowserConfig {
 			// TODO use Firefox3Locator
 			File binaryFile = new File(properties.getProperty("browserBin"));
 			FirefoxBinary binary = new FirefoxBinary(binaryFile);
+			
+			// can be used for headless mode. (Xvfb needs to be running for the specified display)
+			if(properties.containsKey("display")) {
+				binary.setEnvironmentProperty("DISPLAY", properties.getProperty("display"));
+			}
 			FirefoxProfile profile = new FirefoxProfile();
 			// enable native events
 			profile.setEnableNativeEvents(true); 


### PR DESCRIPTION
The display property can now be set within the properties file for the BrowserConfig. This way it can easily be used for headless mode without the need to pass the display number through multiple constructors or similar.
